### PR TITLE
Use standard path for storage_dir

### DIFF
--- a/DependencyInjection/AcmePhpExtension.php
+++ b/DependencyInjection/AcmePhpExtension.php
@@ -16,7 +16,6 @@ use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Extension\PrependExtensionInterface;
 use Symfony\Component\DependencyInjection\Loader;
 use Symfony\Component\HttpKernel\DependencyInjection\Extension;
-use Webmozart\PathUtil\Path;
 
 /**
  * This is the class that loads and manages the bundle configuration.
@@ -39,7 +38,7 @@ class AcmePhpExtension extends Extension implements PrependExtensionInterface
         $loader->load('services.xml');
 
         $container->setParameter('acme_php.domains_configurations', (array) $config['domains']);
-        $container->setParameter('acme_php.certificate_dir', Path::canonicalize($config['certificate_dir']));
+        $container->setParameter('acme_php.certificate_dir', $config['certificate_dir']);
         $container->setParameter('acme_php.certificate_authority', $config['certificate_authority']);
         $container->setParameter('acme_php.contact_email', $config['contact_email']);
     }

--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -68,7 +68,7 @@ class Configuration implements ConfigurationInterface
                 ->scalarNode('certificate_dir')
                     ->info('Certification location directory.')
                     ->cannotBeEmpty()
-                    ->defaultValue('~/.acmephp')
+                    ->defaultValue('%kernel.root_dir%/certs')
                 ->end()
                 ->scalarNode('certificate_authority')
                     ->info('Name of the certificate authority.')

--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ $ ./bin/console acmephp:generate
 The first time you run this command, AmePhpBundle will request a new
 certificate to the configured Certificate Autority (default
 [Letsencrypt](https://letsencrypt.org)) and store the generated certificate in
-the configured folder (default `~/.acmephp`).
+the configured folder (default `%kernel.root_dir%/certs`).
 
 ### Automatic renewal
 
@@ -103,10 +103,6 @@ $ crontab -e
 > After regenerating a certificate you have to reload the web server to take
 the changes into account.
 
-> If you use a dedicated cron file in `/etc/cron.d/` be carrefull of the
-certificate storage location (configured by default in the `$HOME` directory)
-which is related to the user who run the command.
-
 
 Configuration reference
 -----------------------
@@ -115,10 +111,10 @@ Configuration reference
 # app/config/config.yml
 
 acme_php:
-    # Certificates locations. Default: `~/.acmephp`
+    # Certificates locations. Default: `%kernel.root_dir%/certs`
     # Beware to use a directory readable by the web server
     # It should be writable too, to store certificates, keys and challenges.
-    certificate_dir: ~/.acmephp
+    certificate_dir: %kernel.root_dir%/certs
     
     # Certificate Authority used to deliver certificates. Default: `letsencrypt`. Available values : `letsencrypt`
     # You can use your own Certificate Authority by :
@@ -174,7 +170,7 @@ $ bin/console acmephp:generate
 The certificates will be stored in the folder defined by the parameter `certificate_dir`. 
 
 ```
-$ tree ~/.acmephp
+$ tree ./certs
 ├── account                   # Your account's keys
 │   ├── private.pem
 │   └── public.pem

--- a/Tests/Acme/KeyPair/KeyPairProviderTest.php
+++ b/Tests/Acme/KeyPair/KeyPairProviderTest.php
@@ -39,7 +39,7 @@ class KeyPairProviderTest extends \PHPUnit_Framework_TestCase
         $this->mockLogger = $this->prophesize(LoggerInterface::class);
         $this->mockManager = $this->prophesize(KeyPairManager::class);
         $this->mockStorage = $this->prophesize(KeyPairStorage::class);
-        $this->mockStorage->getRootPath()->willReturn('~/.acme/certificates');
+        $this->mockStorage->getRootPath()->willReturn('%kernel.root_dir%/certs/domains');
 
         $this->service = new KeyPairProvider($this->mockManager->reveal(), $this->mockStorage->reveal());
         $this->service->setLogger($this->mockLogger->reveal());

--- a/composer.json
+++ b/composer.json
@@ -39,7 +39,6 @@
         "symfony/filesystem": "^2.3|^3.0",
         "symfony/dependency-injection": "^2.7|^3.0",
         "symfony/finder": "^2.3|^3.0",
-        "webmozart/path-util": "^1.0|^2.0",
         "acmephp/core": "1.0.x-dev"
     },
     "require-dev": {

--- a/features/bootstrap/FeatureContext.php
+++ b/features/bootstrap/FeatureContext.php
@@ -132,7 +132,6 @@ class FeatureContext implements Context, SnippetAcceptingContext
     protected function getDefaultConfig()
     {
         return [
-            'certificate_dir' => '%kernel.root_dir%/certs',
             'certificate_authority' => 'boulder',
             'contact_email' => 'test@acmephp.com',
             'default_distinguished_name' => [


### PR DESCRIPTION
The default path `~/.acmephp` is not usable with this bundle: When the parameter is evaluated by the webserver, it fail, because the user may not have `HOME` (like in docker images).

I replace it by `%kernel.root_dir%/certs`  (aka `app/certs`). But, I'm opened to any idea (may be .`/etc/acmephp/`)
